### PR TITLE
lock: fix so it can succeed after failing

### DIFF
--- a/lock/lock_darwin_amd64.go
+++ b/lock/lock_darwin_amd64.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -33,18 +32,6 @@ func init() {
 }
 
 func lockFcntl(name string) (io.Closer, error) {
-	abs, err := filepath.Abs(name)
-	if err != nil {
-		return nil, err
-	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
-		return nil, fmt.Errorf("file %q already locked", abs)
-	}
-	locked[abs] = true
-	lockmu.Unlock()
-
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
@@ -52,7 +39,7 @@ func lockFcntl(name string) (io.Closer, error) {
 
 	f, err := os.Create(name)
 	if err != nil {
-		return nil, fmt.Errorf("Lock Create of %s (abs: %s) failed: %v", name, abs, err)
+		return nil, fmt.Errorf("Lock Create of %s failed: %v", name, err)
 	}
 
 	// This type matches C's "struct flock" defined in /usr/include/sys/fcntl.h.
@@ -76,5 +63,5 @@ func lockFcntl(name string) (io.Closer, error) {
 		f.Close()
 		return nil, errno
 	}
-	return &unlocker{f, abs}, nil
+	return &unlocker{f, name}, nil
 }

--- a/lock/lock_freebsd.go
+++ b/lock/lock_freebsd.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -30,18 +29,6 @@ func init() {
 }
 
 func lockFcntl(name string) (io.Closer, error) {
-	abs, err := filepath.Abs(name)
-	if err != nil {
-		return nil, err
-	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
-		return nil, fmt.Errorf("file %q already locked", abs)
-	}
-	locked[abs] = true
-	lockmu.Unlock()
-
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
@@ -75,5 +62,5 @@ func lockFcntl(name string) (io.Closer, error) {
 		f.Close()
 		return nil, errno
 	}
-	return &unlocker{f, abs}, nil
+	return &unlocker{f, name}, nil
 }

--- a/lock/lock_linux_amd64.go
+++ b/lock/lock_linux_amd64.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -33,18 +32,6 @@ func init() {
 }
 
 func lockFcntl(name string) (io.Closer, error) {
-	abs, err := filepath.Abs(name)
-	if err != nil {
-		return nil, err
-	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
-		return nil, fmt.Errorf("file %q already locked", abs)
-	}
-	locked[abs] = true
-	lockmu.Unlock()
-
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
@@ -76,5 +63,5 @@ func lockFcntl(name string) (io.Closer, error) {
 		f.Close()
 		return nil, errno
 	}
-	return &unlocker{f, abs}, nil
+	return &unlocker{f, name}, nil
 }

--- a/lock/lock_linux_arm.go
+++ b/lock/lock_linux_arm.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -33,18 +32,6 @@ func init() {
 }
 
 func lockFcntl(name string) (io.Closer, error) {
-	abs, err := filepath.Abs(name)
-	if err != nil {
-		return nil, err
-	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
-		return nil, fmt.Errorf("file %q already locked", abs)
-	}
-	locked[abs] = true
-	lockmu.Unlock()
-
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
@@ -77,5 +64,5 @@ func lockFcntl(name string) (io.Closer, error) {
 		f.Close()
 		return nil, errno
 	}
-	return &unlocker{f, abs}, nil
+	return &unlocker{f, name}, nil
 }

--- a/lock/lock_plan9.go
+++ b/lock/lock_plan9.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 )
 
 func init() {
@@ -28,28 +27,15 @@ func init() {
 }
 
 func lockPlan9(name string) (io.Closer, error) {
-	var f *os.File
-	abs, err := filepath.Abs(name)
-	if err != nil {
-		return nil, err
-	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
-		return nil, fmt.Errorf("file %q already locked", abs)
-	}
-	locked[abs] = true
-	lockmu.Unlock()
-
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
 	}
 
-	f, err = os.OpenFile(name, os.O_RDWR|os.O_CREATE, os.ModeExclusive|0644)
+	f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE, os.ModeExclusive|0644)
 	if err != nil {
-		return nil, fmt.Errorf("Lock Create of %s (abs: %s) failed: %v", name, abs, err)
+		return nil, fmt.Errorf("Lock Create of %s failed: %v", name, err)
 	}
 
-	return &unlocker{f, abs}, nil
+	return &unlocker{f, name}, nil
 }


### PR DESCRIPTION
Currently there is a bug where if the lock fails once (for example
because the file is locked) then it will never succeed, because
the map entry is never set to false in this case.

Rather than fix in every place, we factor out the common code
from all the implementations and apply the fix there.

We also fix the issue that if the file is locked and the portable code
is being used, the error message says "file has non-zero size"
rather than "already locked".

The tests are changed to catch this case - they fail as expected when run
against the old code.