### PR TITLE
lock: clear the in-memory lock flag if we failed to acquire a flock.

### DIFF
--- a/lock/lock_freebsd.go
+++ b/lock/lock_freebsd.go
@@ -34,21 +34,19 @@ func lockFcntl(name string) (io.Closer, error) {
 	if err != nil {
 		return nil, err
 	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
+	if locked.testAndSet(abs) {
 		return nil, fmt.Errorf("file %q already locked", abs)
 	}
-	locked[abs] = true
-	lockmu.Unlock()
 
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
+		locked.clear(abs)
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
 	}
 
 	f, err := os.Create(name)
 	if err != nil {
+		locked.clear(abs)
 		return nil, err
 	}
 
@@ -73,6 +71,7 @@ func lockFcntl(name string) (io.Closer, error) {
 	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), uintptr(syscall.F_SETLK), uintptr(unsafe.Pointer(&k)))
 	if errno != 0 {
 		f.Close()
+		locked.clear(abs)
 		return nil, errno
 	}
 	return &unlocker{f, abs}, nil

--- a/lock/lock_linux_amd64.go
+++ b/lock/lock_linux_amd64.go
@@ -37,21 +37,19 @@ func lockFcntl(name string) (io.Closer, error) {
 	if err != nil {
 		return nil, err
 	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
+	if locked.testAndSet(abs) {
 		return nil, fmt.Errorf("file %q already locked", abs)
 	}
-	locked[abs] = true
-	lockmu.Unlock()
 
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
+		locked.clear(abs)
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
 	}
 
 	f, err := os.Create(name)
 	if err != nil {
+		locked.clear(abs)
 		return nil, err
 	}
 
@@ -74,6 +72,7 @@ func lockFcntl(name string) (io.Closer, error) {
 	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), uintptr(syscall.F_SETLK), uintptr(unsafe.Pointer(&k)))
 	if errno != 0 {
 		f.Close()
+		locked.clear(abs)
 		return nil, errno
 	}
 	return &unlocker{f, abs}, nil

--- a/lock/lock_linux_arm.go
+++ b/lock/lock_linux_arm.go
@@ -37,21 +37,19 @@ func lockFcntl(name string) (io.Closer, error) {
 	if err != nil {
 		return nil, err
 	}
-	lockmu.Lock()
-	if locked[abs] {
-		lockmu.Unlock()
+	if locked.testAndSet(abs) {
 		return nil, fmt.Errorf("file %q already locked", abs)
 	}
-	locked[abs] = true
-	lockmu.Unlock()
 
 	fi, err := os.Stat(name)
 	if err == nil && fi.Size() > 0 {
+		locked.clear(abs)
 		return nil, fmt.Errorf("can't Lock file %q: has non-zero size", name)
 	}
 
 	f, err := os.Create(name)
 	if err != nil {
+		locked.clear(abs)
 		return nil, err
 	}
 
@@ -75,6 +73,7 @@ func lockFcntl(name string) (io.Closer, error) {
 	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), uintptr(F_SETLK), uintptr(unsafe.Pointer(&k)))
 	if errno != 0 {
 		f.Close()
+		locked.clear(abs)
 		return nil, errno
 	}
 	return &unlocker{f, abs}, nil

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -129,3 +129,35 @@ func testLock(t *testing.T, portable bool) {
 	}
 	lk3.Close()
 }
+
+func TestFailedLock(t *testing.T) {
+	td, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(td)
+
+	path := filepath.Join(td, "foo.lock")
+
+	// Write something to the file to let Lock() fail below.
+	if err := ioutil.WriteFile(path, []byte("foo"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Lock(path)
+	if err == nil {
+		t.Fatalf("expected lock to fail")
+	}
+
+	if err := os.Truncate(path, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	lk, err := Lock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lk.Close(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
As @bradfitz mentioned in https://github.com/camlistore/lock/issues/12#issuecomment-174360194 , the package is moved here, but from the code, it seems the behavior is still the same here. 

This PR clears the in-memory map entry when the locking action fails. It also wraps the mutex and map into a struct for cleanness.

Also added a test to verify that a second Lock() can still succeed if the first one fails.