### PR TITLE
add canonical import paths

### DIFF
--- a/bytereplacer/bytereplacer.go
+++ b/bytereplacer/bytereplacer.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package bytereplacer provides a utility for replacing parts of byte slices.
-package bytereplacer
+package bytereplacer // import "go4.org/bytereplacer"
 
 import "bytes"
 

--- a/cloud/cloudlaunch/cloudlaunch.go
+++ b/cloud/cloudlaunch/cloudlaunch.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package cloudlaunch helps binaries run themselves on The Cloud, copying
 // themselves to GCE.
-package cloudlaunch
+package cloudlaunch // import "go4.org/cloud/cloudlaunch"
 
 import (
 	"encoding/json"

--- a/cloud/google/gceutil/gceutil.go
+++ b/cloud/google/gceutil/gceutil.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package gceutil provides utility functions to help with instances on
 // Google Compute Engine.
-package gceutil
+package gceutil // import "go4.org/cloud/google/gceutil"
 
 import (
 	"encoding/json"

--- a/cloud/google/gcsutil/storage.go
+++ b/cloud/google/gcsutil/storage.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package gcsutil provides tools for accessing Google Cloud Storage until they can be
 // completely replaced by google.golang.org/cloud/storage.
-package gcsutil
+package gcsutil // import "go4.org/cloud/google/gcsutil"
 
 import (
 	"encoding/xml"

--- a/ctxutil/ctxutil.go
+++ b/ctxutil/ctxutil.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package ctxutil contains golang.org/x/net/context related utilities.
-package ctxutil
+package ctxutil // import "go4.org/ctxutil"
 
 import (
 	"net/http"

--- a/errorutil/highlight.go
+++ b/errorutil/highlight.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package errorutil helps make better error messages.
-package errorutil
+package errorutil // import "go4.org/errorutil"
 
 import (
 	"bufio"

--- a/fault/fault.go
+++ b/fault/fault.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package fault handles fault injection for testing.
-package fault
+package fault // import "go4.org/fault"
 
 import (
 	"errors"

--- a/jsonconfig/jsonconfig.go
+++ b/jsonconfig/jsonconfig.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package jsonconfig defines a helper type for JSON objects to be
 // used for configuration.
-package jsonconfig
+package jsonconfig // import "go4.org/jsonconfig"
 
 import (
 	"fmt"

--- a/legal/legal.go
+++ b/legal/legal.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package legal provides in-process storage for compiled-in licenses.
-package legal
+package legal // import "go4.org/legal"
 
 var licenses []string
 

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package lock is a file locking library.
-package lock
+package lock // import "go4.org/lock"
 
 import (
 	"encoding/json"

--- a/oauthutil/oauth.go
+++ b/oauthutil/oauth.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package oauthutil contains OAuth 2 related utilities.
-package oauthutil
+package oauthutil // import "go4.org/oauthutil"
 
 import (
 	"encoding/json"

--- a/syncutil/syncdebug/syncdebug.go
+++ b/syncutil/syncdebug/syncdebug.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package syncdebug contains facilities for debugging synchronization
 // problems.
-package syncdebug
+package syncdebug // import "go4.org/syncutil/syncdebug"
 
 import (
 	"bytes"

--- a/types/types.go
+++ b/types/types.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package types provides various common types.
-package types
+package types // import "go4.org/types"
 
 import (
 	"bytes"

--- a/wkfs/gcs/gcs.go
+++ b/wkfs/gcs/gcs.go
@@ -20,7 +20,7 @@ limitations under the License.
 //
 // It was initially only meant for small files, and as such, it can only
 // read files smaller than 1MB for now.
-package gcs
+package gcs // import "go4.org/wkfs/gcs"
 
 import (
 	"bytes"

--- a/wkfs/wkfs.go
+++ b/wkfs/wkfs.go
@@ -25,7 +25,7 @@ limitations under the License.
 // Example of top-level well-known directories that might be
 // registered include /gcs/bucket/object for Google Cloud Storage or
 // /s3/bucket/object for AWS S3.
-package wkfs
+package wkfs // import "go4.org/wkfs"
 
 import (
 	"io"


### PR DESCRIPTION
The import path was added to the go file that included the package
documentation if one existed.  Otherwise, I used what seemed to be the
primary file for the package.