### PR TITLE
fix: functest normalize panic nil results

### DIFF
--- a/testing/functest/functest.go
+++ b/testing/functest/functest.go
@@ -212,7 +212,12 @@ func (f *Func) Test(t testing.TB, cases ...*Case) {
 }
 
 func (f *Func) checkCall(in []reflect.Value) (out []reflect.Value, didPanic bool, panicValue interface{}) {
-	defer func() { panicValue = recover() }()
+	defer func() {
+		panicValue = recover()
+		if _, ok := panicValue.(*runtime.PanicNilError); ok {
+			panicValue = nil
+		}
+	}()
 	didPanic = true
 	out = f.fv.Call(in)
 	didPanic = false

--- a/testing/functest/functest_test.go
+++ b/testing/functest/functest_test.go
@@ -111,7 +111,7 @@ func TestPanic(t *testing.T) {
 		f.Case("panic with nil").In(true, nil),
 	)
 	want := `LOG: Got res: {Result:[] Panic:boom Panicked:true}
-ERR: panic with nil: condPanic(true, <nil>): panicked with panic called with nil argument
+ERR: panic with nil: condPanic(true, <nil>): panicked with <nil>
 `
 	if got := trec.String(); got != want {
 		t.Errorf("Output mismatch.\nGot:\n%v\nWant:\n%v\n", got, want)


### PR DESCRIPTION
Hello maintainers:

Go 1.21+ returns *runtime.PanicNilError from recover() for panic(nil), unless GODEBUG=panicnil=1 is set.

functest.Result already separates the panic value from whether a panic occurred, so normalize *runtime.PanicNilError back to nil and keep Panicked=true for stable panic(nil) handling across Go versions.

## References
- runtime.PanicNilError: https://pkg.go.dev/runtime#PanicNilError
- panic: https://pkg.go.dev/builtin#panic